### PR TITLE
Renamed CancelOrder event

### DIFF
--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -39,7 +39,7 @@ contract Exchange is Initializable, Pausable {
 
     /* --- EVENTS --- */
 
-    event CancelOrder(uint64 id);
+    event NewCancelOrder(uint64 id);
     event NewBestAsk(address indexed baseToken, address indexed tradeToken, uint price);
     event NewAsk(address indexed baseToken, address indexed tradeToken, uint price);
     event NewBid(address indexed baseToken, address indexed tradeToken, uint price);
@@ -179,7 +179,7 @@ contract Exchange is Initializable, Pausable {
 
         Pair storage pair = pairs[order.baseToken][order.tradeToken];
         ListItem memory orderItem = excludeItem(pair, id);
-        emit CancelOrder(id);
+        emit NewCancelOrder(id);
 
         if (pair.bestBid == id) {
             pair.bestBid = orderItem.prev;

--- a/test/Exchange.test.js
+++ b/test/Exchange.test.js
@@ -218,7 +218,7 @@ describe("Exchange", () => {
             const order = buy(100, 5);
             let orderId;
             const newBestBidWatcher = exchange.NewBestBid();
-            const cancelOrderWatcher = exchange.CancelOrder();
+            const cancelOrderWatcher = exchange.NewCancelOrder();
             return placeOrder(order)
                 .then(id => orderId = id)
                 .then(() => cancelOrder(orderId, order.from))
@@ -233,7 +233,7 @@ describe("Exchange", () => {
             const order = sell(100, 5);
             let orderId;
             const newBestAskWatcher = exchange.NewBestAsk();
-            const cancelOrderWatcher = exchange.CancelOrder();
+            const cancelOrderWatcher = exchange.NewCancelOrder();
             return placeOrder(order)
                 .then(id => orderId = id)
                 .then(() => cancelOrder(orderId, order.from))
@@ -339,7 +339,7 @@ describe("Exchange", () => {
         it("should cancel a sell order from the middle of sell orders", () => {
             const order = sell(110, 5);
             const orderState = {prev: 1, next: 0};
-            const cancelOrderWatcher = exchange.CancelOrder();
+            const cancelOrderWatcher = exchange.NewCancelOrder();
             return placeOrder(sell(100, 5))
                 .then(() => placeOrder(order))
                 .then(() => placeOrder(sell(120, 5)))
@@ -354,7 +354,7 @@ describe("Exchange", () => {
         it("should cancel a buy order from the middle of buy orders", () => {
             const order = buy(110, 5);
             const orderState = {prev: 1, next: 0};
-            const cancelOrderWatcher = exchange.CancelOrder();
+            const cancelOrderWatcher = exchange.NewCancelOrder();
             return placeOrder(buy(100, 5))
                 .then(() => placeOrder(order))
                 .then(() => placeOrder(buy(120, 5)))
@@ -624,7 +624,7 @@ describe("Exchange", () => {
             const exchangeEtherBalanceBefore = await web3.eth.getBalance(exchange.address)
     
             const newOrderEventWatcher = exchange.NewOrder();
-            const cancelOrderEventWatcher = exchange.CancelOrder();
+            const cancelOrderEventWatcher = exchange.NewCancelOrder();
             await fallbackTrap.buy(order.baseToken, order.tradeToken, fallbackTrap.address, order.amount, order.price, { from: order.from, value: order.amount * price, gasPrice: 0 })
             const id = newOrderEventWatcher.get()[0].args.id;
             await fallbackTrap.cancelOrder(id, { from: buyer, gasPrice:0, value: 0 });
@@ -640,7 +640,7 @@ describe("Exchange", () => {
             await fallbackTrap.arm();
     
             const newOrderEventWatcher = exchange.NewOrder();
-            const cancelOrderEventWatcher = exchange.CancelOrder();
+            const cancelOrderEventWatcher = exchange.NewCancelOrder();
             await fallbackTrap.buy(order.baseToken, order.tradeToken, fallbackTrap.address, order.amount, order.price, { from: order.from, value: order.amount * price, gasPrice: 0 })
             const id = newOrderEventWatcher.get()[0].args.id;
             await fallbackTrap.cancelOrder(id, { from: buyer, gasPrice:0, value: 0 });


### PR DESCRIPTION
Renamed to NewCancelOrder because ABI is confused with function with the same name.