### PR TITLE
TimeRange update

### DIFF
--- a/contracts/libraries/OrderHistory.sol
+++ b/contracts/libraries/OrderHistory.sol
@@ -51,14 +51,14 @@ library OrderHistory {
     view
     returns (uint64[], uint[], uint[], uint[], bool[], uint64[], uint64[])
   {
-    if (timeRange[0] >= timeRange[1]) {
+    if (timeRange[0] > timeRange[1]) {
       return;
     }
 
     uint startIndex = self.timestamps.findUpperBound(timeRange[0]);
     uint endIndex = self.timestamps.findUpperBound(timeRange[1]);
 
-    if (startIndex >= endIndex) {
+    if (startIndex > endIndex) {
       return;
     }
 

--- a/contracts/libraries/TradeHistory.sol
+++ b/contracts/libraries/TradeHistory.sol
@@ -56,14 +56,14 @@ library TradeHistory {
     view
     returns (uint64[], uint[], uint[], bool[], uint64[])
   {
-    if (timeRange[0] >= timeRange[1]) {
+    if (timeRange[0] > timeRange[1]) {
       return;
     }
 
     uint startIndex = self.timestamps.findUpperBound(timeRange[0]);
     uint endIndex = self.timestamps.findUpperBound(timeRange[1]);
 
-    if (startIndex >= endIndex) {
+    if (startIndex > endIndex) {
       return;
     }
 


### PR DESCRIPTION
When developing the new way to load Trade History, I ran into some issues.

If I want to load trades from a particular second - so `timeRange = [timestamp1, timestamp1]`
I receive 0 trades (because of `timeRange[0] >= timeRange[1]` condition)

Also if `timeRange = [timestamp1, timestamp2]`, and there is only one trade in this timeRange, I guess I get 0 as well because of `startIndex >= endIndex` condition.

Not sure if these proposed changes make sense. Or was `timeRange[1]` supposed to be exclusive?