### PR TITLE
[Possibly bug] Trades resulting in a small order

### DIFF
--- a/test/Exchange.test.js
+++ b/test/Exchange.test.js
@@ -837,6 +837,20 @@ contract("Exchange", () => {
               {id: 4, owner: seller, price: ask14.price, originalAmount: ask14.amount, amount: ask14.amount}
             ], MAX_GET_RETURN_SIZE))
       })
+
+      it.only("should allow to trade two trades resulting in 0.0001 order", () => {
+        const sellOrderOne = sell(4, 2);
+        const buyOrder = buy(4, '1.9999');
+        return placeOrder(sellOrderOne)
+            .then(() => placeOrder(buyOrder))
+      })
+
+      it.only("should allow to trade two trades resulting in 0.00001 order", () => {
+        const sellOrderOne = sell(4, 2);
+        const buyOrder = buy(4, '1.99999');
+        return placeOrder(sellOrderOne)
+            .then(() => placeOrder(buyOrder))
+      })
     });
 
     describe("Admin", () => {


### PR DESCRIPTION
After updating Exchange.json in UI in [PR](https://github.com/ContractLand/contractland-exchange-ui/pull/355) I had to skip one test regarding small orders because it started failing.

The tests should illustrate the case - the second test is failing (VM revert).
Amount `1.99999` cannot be created in UI but can be created by a script/bot.

Not sure if this is a bug or expected behaviour?
If it's expected then we could change the second test to expect failure and merge these tests.